### PR TITLE
Redis support with Drupal Redis module (implement #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,7 @@ may break the application.
     vim settings.sh
     ```
 
-    - Uncomment `#REDIS_HOST=redis` to enable Drupal Redis module.
-      - Change hostname if needed.
-      - You must have a server running Redis to use this feature (e.g. install `redis` docker-scripts container, https://github.com/docker-scripts/redis)
+
 
   - Build image, create the container and configure it: `ds make`
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ may break the application.
     vim settings.sh
     ```
 
+    - Uncomment `#REDIS_HOST=redis` to enable Drupal Redis module.
+      - Change hostname if needed.
+      - You must have a server running Redis to use this feature (e.g. install `redis` docker-scripts container, https://github.com/docker-scripts/redis)
+
   - Build image, create the container and configure it: `ds make`
 
 

--- a/ds/cmd/config.sh
+++ b/ds/cmd/config.sh
@@ -29,4 +29,6 @@ cmd_config() {
 
     # drush may create some files with wrong permissions, fix them
     ds inject fix-file-permissions.sh
+
+    ds inject install/redis-config.sh
 }

--- a/ds/cmd/config.sh
+++ b/ds/cmd/config.sh
@@ -12,6 +12,7 @@ cmd_config() {
     ds inject install/drupal-make.sh
     ds inject install/drupal-install.sh
     ds inject install/drupal-config.sh
+    ds inject install/redis-config.sh
     ds inject install/drush-config.sh
     ds inject install/apache2.sh
     ds inject install/set-prompt.sh
@@ -29,6 +30,4 @@ cmd_config() {
 
     # drush may create some files with wrong permissions, fix them
     ds inject fix-file-permissions.sh
-
-    ds inject install/redis-config.sh
 }

--- a/ds/scripts/dev/clone.sh
+++ b/ds/scripts/dev/clone.sh
@@ -18,7 +18,8 @@ cp -a $src_dir $dst_dir
 domain=$tag.$DOMAIN
 sed -i $dst_dir/sites/default/settings.php \
     -e "/^\\\$databases = array/,+10  s/'database' => .*/'database' => '$dst',/" \
-    -e "/^\\\$base_url/c \$base_url = \"https://$domain\";"
+    -e "/^\\\$base_url/c \$base_url = \"https://$domain\";" \
+    -e "/cache_prefix/ s/:lbd/:$dst/"
 
 ### create a drush alias
 sed -i /etc/drush/local_lbd.aliases.drushrc.php \

--- a/ds/scripts/install/redis-config.sh
+++ b/ds/scripts/install/redis-config.sh
@@ -1,15 +1,13 @@
 #!/bin/bash -x
+
 source /host/settings.sh
-### check if REDIS_HOST is not empty, else exit
-[[ -n $REDIS_HOST ]] || exit 0 
 
-drupal_settings=$DRUPAL_DIR/sites/default/settings.php
-drush="drush --root=$DRUPAL_DIR --yes"
-$drush dl redis # use first site e.g. @local_proj
-apt install -y php-redis redis-tools
+[[ -n $REDIS_HOST ]] || exit 0
 
+apt -y install php-redis
+drush --root=$DRUPAL_DIR --yes dl redis
 
-cat << EOF "
+cat << EOF >> $DRUPAL_DIR/sites/default/settings.php
 // Redis settings
 \$conf['redis_client_interface'] = 'PhpRedis';
 \$conf['redis_client_host'] = '$REDIS_HOST';
@@ -17,4 +15,5 @@ cat << EOF "
 \$conf['path_inc'] = 'sites/all/modules/redis/redis.path.inc';
 \$conf['cache_backends'][] = 'sites/all/modules/redis/redis.autoload.inc';
 \$conf['cache_default_class'] = 'Redis_Cache';
-" >> $drupal_settings
+\$conf['cache_prefix'] = '$CONTAINER';
+EOF

--- a/ds/scripts/install/redis-config.sh
+++ b/ds/scripts/install/redis-config.sh
@@ -5,7 +5,7 @@ if [ -n "$REDIS_HOST" ];
 then
 	drupal_settings=$DRUPAL_DIR/sites/default/settings.php
 	drush="drush --root=$DRUPAL_DIR --yes"
-	$drush @local_proj dl redis
+	$drush @local_${DRUPAL_DIR} dl redis
 	apt install -y php-redis redis-tools
 	echo "
 // Redis settings

--- a/ds/scripts/install/redis-config.sh
+++ b/ds/scripts/install/redis-config.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -x
+source /host/settings.sh
+
+if [ -n "$REDIS_HOST" ];
+then
+	drupal_settings=$DRUPAL_DIR/sites/default/settings.php
+	drush="drush --root=$DRUPAL_DIR --yes"
+	$drush @local_proj dl redis
+	apt install -y php-redis redis-tools
+	echo "
+// Redis settings
+\$conf['redis_client_interface'] = 'PhpRedis';
+\$conf['redis_client_host'] = '$REDIS_HOST';
+\$conf['lock_inc'] = 'sites/all/modules/redis/redis.lock.inc';
+\$conf['path_inc'] = 'sites/all/modules/redis/redis.path.inc';
+\$conf['cache_backends'][] = 'sites/all/modules/redis/redis.autoload.inc';
+\$conf['cache_default_class'] = 'Redis_Cache';
+" >> $drupal_settings
+
+	service apache2 restart
+fi
+

--- a/ds/scripts/install/redis-config.sh
+++ b/ds/scripts/install/redis-config.sh
@@ -5,7 +5,7 @@ if [ -n "$REDIS_HOST" ];
 then
 	drupal_settings=$DRUPAL_DIR/sites/default/settings.php
 	drush="drush --root=$DRUPAL_DIR --yes"
-	$drush `drush sa` dl redis
+	$drush `drush sa | head -n 1` dl redis # use first site e.g. @local_proj
 	apt install -y php-redis redis-tools
 	echo "
 // Redis settings

--- a/ds/scripts/install/redis-config.sh
+++ b/ds/scripts/install/redis-config.sh
@@ -5,7 +5,7 @@ if [ -n "$REDIS_HOST" ];
 then
 	drupal_settings=$DRUPAL_DIR/sites/default/settings.php
 	drush="drush --root=$DRUPAL_DIR --yes"
-	$drush @local_${DRUPAL_DIR} dl redis
+	$drush `drush sa` dl redis
 	apt install -y php-redis redis-tools
 	echo "
 // Redis settings

--- a/ds/scripts/install/redis-config.sh
+++ b/ds/scripts/install/redis-config.sh
@@ -15,5 +15,5 @@ cat << EOF >> $DRUPAL_DIR/sites/default/settings.php
 \$conf['path_inc'] = 'sites/all/modules/redis/redis.path.inc';
 \$conf['cache_backends'][] = 'sites/all/modules/redis/redis.autoload.inc';
 \$conf['cache_default_class'] = 'Redis_Cache';
-\$conf['cache_prefix'] = '$CONTAINER';
+\$conf['cache_prefix'] = '$CONTAINER:lbd';
 EOF

--- a/ds/scripts/install/redis-config.sh
+++ b/ds/scripts/install/redis-config.sh
@@ -1,13 +1,13 @@
 #!/bin/bash -x
 source /host/settings.sh
+### check if REDIS_HOST is not empty, else exit
+[[ -n $REDIS_HOST ]] || exit 0 
 
 drupal_settings=$DRUPAL_DIR/sites/default/settings.php
 drush="drush --root=$DRUPAL_DIR --yes"
 $drush dl redis # use first site e.g. @local_proj
 apt install -y php-redis redis-tools
 
-### check if REDIS_HOST is not empty, else exit
-[[ -n $REDIS_HOST ]] || exit 0 
 
 cat << EOF "
 // Redis settings
@@ -18,7 +18,3 @@ cat << EOF "
 \$conf['cache_backends'][] = 'sites/all/modules/redis/redis.autoload.inc';
 \$conf['cache_default_class'] = 'Redis_Cache';
 " >> $drupal_settings
-
-service apache2 restart
-
-

--- a/ds/scripts/install/redis-config.sh
+++ b/ds/scripts/install/redis-config.sh
@@ -1,13 +1,15 @@
 #!/bin/bash -x
 source /host/settings.sh
 
-if [ -n "$REDIS_HOST" ];
-then
-	drupal_settings=$DRUPAL_DIR/sites/default/settings.php
-	drush="drush --root=$DRUPAL_DIR --yes"
-	$drush `drush sa | head -n 1` dl redis # use first site e.g. @local_proj
-	apt install -y php-redis redis-tools
-	echo "
+drupal_settings=$DRUPAL_DIR/sites/default/settings.php
+drush="drush --root=$DRUPAL_DIR --yes"
+$drush dl redis # use first site e.g. @local_proj
+apt install -y php-redis redis-tools
+
+### check if REDIS_HOST is not empty, else exit
+[[ -n $REDIS_HOST ]] || exit 0 
+
+cat << EOF "
 // Redis settings
 \$conf['redis_client_interface'] = 'PhpRedis';
 \$conf['redis_client_host'] = '$REDIS_HOST';
@@ -17,6 +19,6 @@ then
 \$conf['cache_default_class'] = 'Redis_Cache';
 " >> $drupal_settings
 
-	service apache2 restart
-fi
+service apache2 restart
+
 

--- a/ds/settings.sh
+++ b/ds/settings.sh
@@ -30,4 +30,5 @@ DBPASS=lbd
 # If you want to use Redis, put its hostname or IP address here
 # Else you can comment out this variable or set as empty.
 # Default value is 'redis'.
-REDIS_HOST=redis
+REDIS_HOST=
+#REDIS_HOST=redis

--- a/ds/settings.sh
+++ b/ds/settings.sh
@@ -26,3 +26,8 @@ DBPORT=3306
 DBNAME=lbd
 DBUSER=lbd
 DBPASS=lbd
+
+# If you want to use Redis, put its hostname or IP address here
+# Else you can comment out this variable or set as empty.
+# Default value is 'redis'.
+REDIS_HOST=redis

--- a/ds/settings.sh
+++ b/ds/settings.sh
@@ -27,8 +27,10 @@ DBNAME=lbd
 DBUSER=lbd
 DBPASS=lbd
 
-# If you want to use Redis, put its hostname or IP address here
-# Else you can comment out this variable or set as empty.
-# Default value is 'redis'.
+### Uncomment #REDIS_HOST=redis to enable Drupal Redis module.
+### Change hostname if needed.
+### You must have a server running Redis to use this feature 
+### (e.g. install `redis` docker-scripts container, https://github.com/docker-scripts/redis)
+
 REDIS_HOST=
 #REDIS_HOST=redis


### PR DESCRIPTION
In settings.sh, there is optional REDIS_HOST variable.
when it is set, e.g. REDIS_HOST=redis, the config script will install Redis module and configured to use Redis server with designated hostname.

 (Implements #12)